### PR TITLE
Fix handleErrorState exception

### DIFF
--- a/app/src/main/java/com/rasalexman/sresultexample/MainViewModel.kt
+++ b/app/src/main/java/com/rasalexman/sresultexample/MainViewModel.kt
@@ -7,6 +7,7 @@ import com.rasalexman.sresult.data.dto.SEvent
 import com.rasalexman.sresult.data.dto.SResult
 import com.rasalexman.sresult.models.IDropDownItem
 import com.rasalexman.sresultpresentation.extensions.AnyResultMutableLiveData
+import com.rasalexman.sresultpresentation.extensions.launchAsyncTryCatch
 import com.rasalexman.sresultpresentation.extensions.mutableMap
 import com.rasalexman.sresultpresentation.extensions.onEventLiveDataAnyResult
 import com.rasalexman.sresultpresentation.viewModels.BaseViewModel
@@ -134,5 +135,9 @@ class MainViewModel : BaseViewModel() {
             R.menu.menu_add
         }
         toolbarMenu.value = menuResId
+    }
+
+    fun onInvokeErrorHandlerClicked() = launchAsyncTryCatch {
+        throw IllegalArgumentException("Test error message")
     }
 }

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -90,6 +90,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/errorHandlerButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_error_handler"
+            android:layout_marginTop="@dimen/size_16dp"
+            app:onViewClick="@{() -> vm.onInvokeErrorHandlerClicked()}"
+            app:layout_constraintTop_toBottomOf="@+id/menuButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
         <include layout="@layout/item_filter_dropdown"
             android:id="@+id/firstDropDown"
             android:layout_height="wrap_content"
@@ -98,7 +109,7 @@
             android:layout_marginTop="@dimen/size_24dp"
             android:layout_marginHorizontal="@dimen/size_16dp"
             app:selectedItem="@{vm.selectedValue}"
-            app:layout_constraintTop_toBottomOf="@+id/menuButton"
+            app:layout_constraintTop_toBottomOf="@+id/errorHandlerButton"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="button_do_action">Do Action</string>
     <string name="button_state">Show State Flow</string>
     <string name="button_menu">Change Menu</string>
+    <string name="button_error_handler">Error Handler</string>
     <string name="title_profile">User Profile</string>
     <string name="title_bottom_recycler">Bottom Recycler</string>
     <string name="title_empty_vm">Empty ViewModel Screen</string>

--- a/sresultpresentation/src/main/kotlin/com/rasalexman/sresultpresentation/extensions/ViewModelExt.kt
+++ b/sresultpresentation/src/main/kotlin/com/rasalexman/sresultpresentation/extensions/ViewModelExt.kt
@@ -23,7 +23,9 @@ fun BaseContextViewModel.launchUITryCatch(
     catchBlock: ((Throwable) -> Unit)? = null, tryBlock: suspend CoroutineScope.() -> Unit
 ) {
     val exceptionHandler = CoroutineExceptionHandler { _, e ->
-        catchBlock?.invoke(e) ?: handleErrorState(e.toErrorResult())
+        catchBlock?.invoke(e) ?: viewModelScope.launch {
+            handleErrorState(e.toErrorResult())
+        }
     }
     viewModelScope.launch(
         viewModelScope.coroutineContext + dispatcher + superVisorJob + exceptionHandler,
@@ -37,7 +39,9 @@ fun BaseContextViewModel.launchAsyncTryCatch(
     tryBlock: suspend CoroutineScope.() -> Unit
 ) {
     val exceptionHandler = CoroutineExceptionHandler { _, e ->
-        catchBlock?.invoke(e) ?: handleErrorState(e.toErrorResult())
+        catchBlock?.invoke(e) ?: viewModelScope.launch {
+            handleErrorState(e.toErrorResult())
+        }
     }
     launchAsync(exceptionHandler = exceptionHandler, block = tryBlock)
 }


### PR DESCRIPTION
CoroutineExceptionHandler can be called from background thread, causing handleErrorState to throw. 
Now handleErrorState is always called from main thread.